### PR TITLE
make overlay layman compatible

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-gpo-xdch47
+xdch47


### PR DESCRIPTION
this should make it pass the failed check. you can alternatively change the name at https://github.com/gentoo/api-gentoo-org/pull/195 to gpo-xdch47 but this probably makes more sense.